### PR TITLE
Add co2 Signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build
 _opam
 .vscode
+.co2-token

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The API provides geographic-specific services, which allow you to exploit more f
 
 ### Usage
 
+A very simple use of the region specific API for Great Britain only requires the user to provide Eio's network capability.
+
 <!-- $MDX non-deterministic=output -->
 ```ocaml
 # Eio_main.run @@ fun env ->
@@ -26,5 +28,21 @@ The API provides geographic-specific services, which allow you to exploit more f
 +actual: None
 +index: high
 +
+- : unit = ()
+```
+
+Some APIs require more configuration, for example an access token. In order to use them you will need to construct a configuration and pass this into any calls that are made. For example:
+
+<!-- $MDX non-deterministic=output -->
+```ocaml
+# Eio_main.run @@ fun env ->
+  let token = Eio.Path.(load (env#fs / ".co2-token")) in
+  let t = Carbon.Co2_signal.v token in
+  Carbon.Co2_signal.get_intensity ~net:env#net ~country_code:`FR t
+  |> Eio.traceln "%a" Carbon.Co2_signal.Intensity.pp;;
++country: FR
++datetime: 2022-08-29T11:00:00.000Z
++intensity: 99 gCO2/kWh
++fossil fuel percentage: 15.230000
 - : unit = ()
 ```

--- a/carbon.opam
+++ b/carbon.opam
@@ -13,6 +13,7 @@ depends: [
   "ptime"
   "tls"
   "mirage-crypto-rng"
+  "ISO3166"
   "mdx" {with-test}
   "eio_main" {with-test}
   "odoc" {with-doc}
@@ -37,4 +38,5 @@ dev-repo: "git+https://github.com/geocaml/carbon-intensity.git"
 pin-depends: [
   "http.dev" "git+https://github.com/mirage/ocaml-cohttp#ce5f271b69fe42471ede858c5b8ce8203e3c14ad"
   "cohttp-eio.dev" "git+https://github.com/mirage/ocaml-cohttp#ce5f271b69fe42471ede858c5b8ce8203e3c14ad"
+  "ISO3166.dev" "https://github.com/geocaml/ISO3166#425ce3790f8e0a94ad31dd3ff6033463d645b3db"
 ]

--- a/example/dune
+++ b/example/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries carbon eio_main))

--- a/example/main.ml
+++ b/example/main.ml
@@ -1,0 +1,6 @@
+let () =
+  Eio_main.run @@ fun env ->
+  let token = Eio.Path.(load (env#fs / ".co2-token")) in
+  let t = Carbon.Co2_signal.v token in
+  Carbon.Co2_signal.get_intensity ~net:env#net ~country_code:`FR t
+  |> Eio.traceln "%a" Carbon.Co2_signal.Intensity.pp

--- a/src/carbon.ml
+++ b/src/carbon.ml
@@ -1,1 +1,2 @@
 module Gb = Gb
+module Co2_signal = Co2_signal

--- a/src/carbon.mli
+++ b/src/carbon.mli
@@ -1,1 +1,2 @@
 module Gb = Gb
+module Co2_signal = Co2_signal

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,14 @@
 (library
  (name carbon)
  (public_name carbon)
- (libraries ptime ezjsonm eio.unix mirage-crypto-rng.unix tls cohttp-eio))
+ (libraries
+  ptime
+  ezjsonm
+  eio.unix
+  mirage-crypto-rng.unix
+  tls
+  cohttp-eio
+  uri
+  ISO3166))
 
 (include_subdirs unqualified)

--- a/src/http_client.ml
+++ b/src/http_client.ml
@@ -1,0 +1,24 @@
+open Eio
+open Cohttp_eio
+
+let tls_config =
+  Mirage_crypto_rng_unix.initialize ();
+  let null ?ip:_ ~host:_ _certs = Ok None in
+  Tls.Config.client ~authenticator:null () (* todo: TOFU *)
+
+let get_json ?headers ~net (base, resource) =
+  match Net.getaddrinfo_stream ~service:"https" net base with
+  | [] -> failwith "Host resolution failed"
+  | stream :: _ ->
+      Switch.run @@ fun sw ->
+      let conn = Net.connect ~sw net stream in
+      let conn =
+        Tls_eio.Tls_flow.client_of_flow tls_config
+          ?host:
+            (Domain_name.of_string_exn base
+            |> Domain_name.host |> Result.to_option)
+          conn
+      in
+      let resp = Client.get ?headers ~conn ("https://" ^ base, None) resource in
+      let s = Client.read_fixed resp in
+      Ezjsonm.value_from_string s |> fun v -> Ezjsonm.find v [ "data" ]

--- a/src/plugins/co2_signal.ml
+++ b/src/plugins/co2_signal.ml
@@ -1,0 +1,62 @@
+type t = { token : string }
+
+let v token = { token }
+
+module Endpoints = struct
+  let base = "api.co2signal.com"
+  let version = "v1"
+
+  let uri ~path ~query =
+    Uri.make ~scheme:"https" ~host:base ~path:(version ^ "/" ^ path) ~query ()
+end
+
+let headers t =
+  Http.Header.of_list
+    [
+      ("Accept", "application/json");
+      ("auth-token", t.token);
+      ("Host", Endpoints.base);
+    ]
+
+module Intensity = struct
+  type t = {
+    code : ISO3166.alpha2;
+    datetime : string;
+    carbon_intensity : int;
+    fossil_fuel_percentage : float;
+  }
+
+  let intensity t = t.carbon_intensity
+  let datetime t = t.datetime
+  let country t = t.code
+  let pp_co2 ppf v = Fmt.pf ppf "%i gCO2/kWh" v
+
+  let pp ppf t =
+    Fmt.pf ppf
+      "country: %s@.datetime: %s@.intensity: %a@.fossil fuel percentage: %f"
+      (ISO3166.alpha2_to_string t.code)
+      t.datetime pp_co2 t.carbon_intensity t.fossil_fuel_percentage
+end
+
+let get_intensity ~net ~country_code t =
+  let code = ISO3166.alpha2_to_string country_code in
+  let headers = headers t in
+  let resource =
+    Endpoints.uri ~path:"latest" ~query:[ ("countryCode", [ code ]) ]
+    |> Uri.path_and_query
+  in
+  let data = Http_client.get_json ~net ~headers Endpoints.(base, resource) in
+  match
+    ( J.find data [ "datetime" ],
+      J.find data [ "carbonIntensity" ],
+      J.find data [ "fossilFuelPercentage" ] )
+  with
+  | Some date, Some ci, Some ffp ->
+      Intensity.
+        {
+          code = country_code;
+          datetime = J.to_string date;
+          carbon_intensity = J.to_int ci;
+          fossil_fuel_percentage = J.to_float ffp;
+        }
+  | _ -> invalid_arg "Malformed JSON data for get_intensity"

--- a/src/plugins/co2_signal.mli
+++ b/src/plugins/co2_signal.mli
@@ -1,0 +1,15 @@
+type t
+
+val v : string -> t
+
+module Intensity : sig
+  type t
+
+  val intensity : t -> int
+  val country : t -> ISO3166.alpha2
+  val datetime : t -> string
+  val pp : t Fmt.t
+end
+
+val get_intensity :
+  net:Eio.Net.t -> country_code:ISO3166.alpha2 -> t -> Intensity.t

--- a/src/plugins/gb.mli
+++ b/src/plugins/gb.mli
@@ -27,7 +27,6 @@ end
 
 module Intensity : sig
   type t
-  (** *)
 
   type index = [ `Very_low | `Low | `Moderate | `High | `Very_high ]
   (** The index is a measure of the Carbon Intensity represented as a scale *)

--- a/src/plugins/j.ml
+++ b/src/plugins/j.ml
@@ -2,4 +2,5 @@ let find = Ezjsonm.find_opt
 let to_list = Ezjsonm.get_list
 let to_string = Ezjsonm.get_string
 let to_int = Ezjsonm.get_int
+let to_float = Ezjsonm.get_float
 let null_to_option = function `Null -> None | v -> Some v


### PR DESCRIPTION
This PR adds API bindings for https://www.co2signal.com/ opening up many more locations in the world. The API requires an access-token.